### PR TITLE
throwing an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
+'use strict';
+
 module.exports = function (variableArray) {
 	if (!Array.isArray(variableArray)) {
-		console.error('Array required')
+		console.error('Array required');
 		return;
 	}
 	var missingVariables = [];
@@ -11,6 +13,6 @@ module.exports = function (variableArray) {
 	}
 	if (missingVariables.length) {
 		console.error('Environment variables needed:', JSON.stringify(missingVariables));
-		throw 'Environment variables missing';
+		throw new Error('Environment variables missing');
 	}
-}
+};

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -8,15 +8,15 @@ describe('require-environment-variables', function () {
 
 	it('should verify that process.env.THISISATEST exists', function (done) {
 		expect(function () {
-			requireEnv(['THISISATEST'])
+			requireEnv(['THISISATEST']);
 		}).to.not.throw('Environment variables missing');
 		done();
 	});
 
 	it('should throw an error that process.env.THISDOESNTEXIST is missing', function (done) {
 		expect(function () {
-			requireEnv(['THISDOESNTEXIST'])
-		}).to.throw('Environment variables missing');
+			requireEnv(['THISDOESNTEXIST']);
+		}).to.throw(Error, /Environment variables missing/);
 		done();
 	});
 


### PR DESCRIPTION
This just changes the throw to be an error rather then a string. So if the behavior wants to be caught it will be in a standard format. Eg.

```javascript
try {
  requireENV(['MISSING_VAR']);
} catch (e) {
  // e is an error
}

also added in a few missing semicolons